### PR TITLE
Use Jest for tests instead of Mocha, Chai and NYC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - 'stable'
 
 after_success:
-  - npm run coveralls
+  - cat coverage/lcov.info | node_modules/.bin/coveralls

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Convert a locale id string (LCID) to a unicode regional indicator symbol.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/mocha",
-    "coveralls": "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls"
+    "test": "jest --coverage"
   },
   "repository": {
     "type": "git",
@@ -25,9 +24,7 @@
   },
   "homepage": "https://github.com/10xjs/locale-emoji#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
     "coveralls": "^2.11.16",
-    "mocha": "^3.2.0",
-    "nyc": "^10.1.2"
+    "jest": "^21.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -17,9 +17,11 @@ describe('localeEmoji', function() {
     'sk_Latin_SK': '🇸🇰',
   };
 
-  it('converts LCIDs to flag emojis', function() {
-    Object.keys(tests).forEach(function(from) {
-      expect(localeEmoji(from)).to.equal(tests[from]);
+  Object.keys(tests).forEach(function(from) {
+    var to = tests[from];
+
+    it(from + ' -> ' + to, function() {
+      expect(localeEmoji(from)).to.equal(to);
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-var expect = require('chai').expect;
 var localeEmoji = require('.');
 
 describe('localeEmoji', function() {
@@ -21,11 +20,11 @@ describe('localeEmoji', function() {
     var to = tests[from];
 
     it(from + ' -> ' + to, function() {
-      expect(localeEmoji(from)).to.equal(to);
+      expect(localeEmoji(from)).toEqual(to);
     });
   });
 
   it('should return a empty string for invalid input', function() {
-    expect(localeEmoji('potato')).to.equal('');
+    expect(localeEmoji('potato')).toEqual('');
   });
 });

--- a/test.js
+++ b/test.js
@@ -24,8 +24,6 @@ describe('localeEmoji', function() {
   });
 
   it('should return a empty string for invalid input', function() {
-    Object.keys(tests).forEach(function(from) {
-      expect(localeEmoji('potato')).to.equal('');
-    });
+    expect(localeEmoji('potato')).to.equal('');
   });
 });


### PR DESCRIPTION
see https://facebook.github.io/jest/

The advantage of Jest is its nicely integrated test runner including a `--watch` mode and automatic `--coverage` reporting built-in.