### PR TITLE
Added type declaration to be compatible with TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default function localeEmoji(locale: string): string;


### PR DESCRIPTION
Typescript allows `d.ts` files to be used to describe the types for a "normal" JavaScript file ([documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports)). This PR adds the (very simple) declaration to make your helpful package available ootb to TypeScript programs.